### PR TITLE
Add POD attribute to Point type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 3
 
 [[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "efsim"
 version = "0.1.0"
 dependencies = [
@@ -10,5 +30,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
 name = "util"
 version = "0.1.0"
+dependencies = [
+ "bytemuck",
+]

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,4 +3,5 @@ name = "util"
 version = "0.1.0"
 edition = "2021"
 
-# No dependencies needed!
+[dependencies]
+bytemuck = { version = "1.13.1", features = ["derive"] }

--- a/util/src/math.rs
+++ b/util/src/math.rs
@@ -3,6 +3,7 @@
 //! functionality to operate; less code has fewer bugs!
 
 use std::ops::{Add, Sub, Mul};
+use bytemuck::{Pod, Zeroable};
 
 pub const RELAXED_EPSILON: f32 = 0.001;
 
@@ -11,7 +12,7 @@ pub fn almost_zero(value: f32) -> bool {
 }
 
 /// Represents one point in RxR.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Pod, Zeroable)]
 #[repr(C)]
 pub struct Point(pub f32, pub f32);
 


### PR DESCRIPTION
Eventually, Points will need to go to the GPU and thus be bytemucked. In preparation for this, mark them as POD.