### PR TITLE
Add pre-commit hooks for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: cargo-check
+    -   id: clippy
+    -   id: fmt

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -1,18 +1,15 @@
 //! Defines a small, simplified wrapper over a Winit window.
 
-use winit::{
-    event::{ElementState, Event, MouseButton, WindowEvent},
-    event_loop::EventLoop,
-    dpi::PhysicalSize,
-    window::{Window as WinitWindow, WindowBuilder},
-};
 use raw_window_handle::{
-    HasRawDisplayHandle,
-    HasRawWindowHandle,
-    RawDisplayHandle,
-    RawWindowHandle,
+    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 use std::default::Default;
+use winit::{
+    dpi::PhysicalSize,
+    event::{ElementState, Event, MouseButton, WindowEvent},
+    event_loop::EventLoop,
+    window::{Window as WinitWindow, WindowBuilder},
+};
 
 /// Simplified cursor model containing its position and three major button states.
 #[derive(Clone, Copy, Debug, Default)]
@@ -52,7 +49,7 @@ impl Window {
     pub fn run<F1, F2>(mut self, mut on_redraw: F1, mut on_input: F2) -> !
     where
         F1: FnMut() + 'static,
-        F2: FnMut(InputEvent) + 'static
+        F2: FnMut(InputEvent) + 'static,
     {
         self.ev_loop.run(move |event, _, control_flow| {
             control_flow.set_wait();
@@ -71,32 +68,32 @@ impl Window {
                                 MouseButton::Left => {
                                     self.cursor.left_down = pressed;
                                     mouse_button = InputEventType::MouseLeft;
-                                },
+                                }
                                 MouseButton::Middle => {
                                     self.cursor.middle_down = pressed;
                                     mouse_button = InputEventType::MouseMiddle;
-                                },
+                                }
                                 MouseButton::Right => {
                                     self.cursor.right_down = pressed;
                                     mouse_button = InputEventType::MouseRight;
-                                },
+                                }
                                 _ => return,
                             }
 
                             on_input(InputEvent {
                                 reason: mouse_button,
-                                cursor: self.cursor
+                                cursor: self.cursor,
                             });
-                        },
+                        }
                         WindowEvent::CursorMoved { position, .. } => {
                             self.cursor.x = position.x as f32;
                             self.cursor.y = position.y as f32;
 
                             on_input(InputEvent {
                                 reason: InputEventType::MouseMoved,
-                                cursor: self.cursor
+                                cursor: self.cursor,
                             });
-                        },
+                        }
                         WindowEvent::KeyboardInput { input, .. } => {
                             if let Some(key) = input.virtual_keycode {
                                 let pressed = input.state == ElementState::Pressed;
@@ -105,11 +102,11 @@ impl Window {
                                     cursor: self.cursor,
                                 });
                             }
-                        },
-                        _ => { }, // TODO: Must implement window resizing for the renderer
+                        }
+                        _ => {} // TODO: Must implement window resizing for the renderer
                     }
-                },
-                _ => { },
+                }
+                _ => {}
             }
         });
     }
@@ -118,7 +115,7 @@ impl Window {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_size<T>(title: T, width: u32, height: u32) -> Self
     where
-        T: Into<String>
+        T: Into<String>,
     {
         let ev_loop = EventLoop::new();
         let window = WindowBuilder::new()
@@ -126,8 +123,12 @@ impl Window {
             .with_inner_size(PhysicalSize { width, height })
             .build(&ev_loop)
             .expect("Window creation failed");
-        
-        Self { ev_loop, window, cursor: Default::default() }
+
+        Self {
+            ev_loop,
+            window,
+            cursor: Default::default(),
+        }
     }
 
     pub fn get_size(&self) -> (u32, u32) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-use render::{Window, InputEvent};
+use render::{InputEvent, Window};
 
 fn main() {
     let window = Window::with_size("Interesting Title", 640, 480);
     window.run(
-        || { },
+        || {},
         |event: InputEvent| {
             println!("{:?}", event);
-        }
+        },
     );
 }

--- a/util/src/math.rs
+++ b/util/src/math.rs
@@ -2,8 +2,8 @@
 //! This is intentional, as this project needs very little mathematical
 //! functionality to operate; less code has fewer bugs!
 
-use std::ops::{Add, Sub, Mul};
 use bytemuck::{Pod, Zeroable};
+use std::ops::{Add, Mul, Sub};
 
 pub const RELAXED_EPSILON: f32 = 0.001;
 
@@ -52,7 +52,11 @@ impl Point {
             let a = self.0.abs();
             let b = self.1.abs();
 
-            if a < b { (a, b) } else { (b, a) }
+            if a < b {
+                (a, b)
+            } else {
+                (b, a)
+            }
         };
 
         let recip_b = 1.0 / b;


### PR DESCRIPTION
Fix typos in previous commits.
Add pre-commit hooks to run `cargo clippy` and `cargo fmt`, among others.

Context: I accidentally committed some ill-formatted code after neglecting to run `cargo clippy` and `cargo fmt`. This is easy to do, so we add pre-commit to prevent this in the future.